### PR TITLE
Add zip to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="lbeuk@pm.me"
 RUN apt-get update && apt-get install -y \
     openssh-client \
     git \
+    zip \
     build-essential \
     clang \
     gdb \


### PR DESCRIPTION
In order to package files for grade scope, it is very convenient to have zip installed on the development containers. This change adds the installation of the zip package to the Dockerfile.